### PR TITLE
fix: 版本号的引号错误

### DIFF
--- a/EaseMobSDK.podspec
+++ b/EaseMobSDK.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |spec|
   spec.name         = 'EaseMobSDK'
-  spec.version      = ‘2.1.2’
+  spec.version      = '2.1.2'
   spec.license      = 'MIT'
   spec.summary      = 'An Objective-C client for IM service'
   spec.homepage     = 'https://github.com/winterSleep/EasemobSDK/'
   spec.author       = {'EaseMob Inc.' => 'lizhiping@easemob.com'}
-  spec.source       =  {:git => 'https://github.com/easemob/sdk-ios-cocoapods.git', :tag => ‘2.1.2’}
+  spec.source       =  {:git => 'https://github.com/easemob/sdk-ios-cocoapods.git', :tag => '2.1.2'}
   spec.source_files = "EaseMobSDK/**/*.{h}"
   spec.platform     = :ios, '6.0'
   spec.requires_arc = true


### PR DESCRIPTION
引导格式错误会导致 pod install 时 CocoaPods 出错。
错误类型：https://github.com/CocoaPods/CocoaPods/issues/829
