### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ sdk-ios-cocoapods
 
 环信iOS SDK  CocoaPod repo
 
-从2.0.6开始, 小伙伴们可以使用 Cocoapods 来集成环信啦, 集成方法如下:
+从2.0.6开始, 小伙伴们可以使用 CocoaPods 来集成环信啦, 集成方法如下:
 
 1. Podfile 文件添加如下代码
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
